### PR TITLE
Comparing PokerHands domain like

### DIFF
--- a/src/Blef.GameLogic/PokerHands/!PokerHandHierarchy.txt
+++ b/src/Blef.GameLogic/PokerHands/!PokerHandHierarchy.txt
@@ -1,11 +1,15 @@
-﻿HighStraightFlush - duży poker (kolor) 1 000 000 000 *S
-LowStraightFlush -  mały poker (kolor) 100 000 000 *S
-FourOfKind - kareta (wartość) 10 000 000 *R
-Flush - kolor (kolor) 1 000 000 * S
-FullHouse - full (wartość, wartość) 100 000 + 10R1 +R2
-ThreeOfKind - trójka (wartość) 10 000 + R
-HighStraight - duży strit 5 000
-LowStraight - mały strit 1 000
-TwoPairs - dwie pary (wartość, wartość) 100 + R1 + R2
-Pair - para (wartość) 10R
-HighCard - wysoka karta (wartość) R
+﻿GenericPokerHand określa typ układu, kolejność jak poniżej od najmniej (1) do najbardziej ważnego (11).
+Najpierw porównujemy więc GenericPokerHand. Gdy jest równy przechodzimy do porównania PokerHand.CompareWithinSameGenericPokerHand(PokerHand),
+który jest implementowany dla każdego układu. Dla niektórych układów funkcja ta zwraca '0', bo nie już co porównywać, sam układ jest ważny.
+
+1. HighCard - wysoka karta
+2. Pair - para
+3. TwoPairs - dwie pary
+4. LowStraight - mały
+5. HighStraight - duży
+6. ThreeOfKind - trójka
+7. FullHouse - full
+8. Flush - kolor
+9. FourOfKind - kareta
+10. LowStraightFlush -  mały poker
+11. HighStraightFlush - duży poker

--- a/src/Blef.GameLogic/PokerHands/Flush.cs
+++ b/src/Blef.GameLogic/PokerHands/Flush.cs
@@ -14,6 +14,11 @@
             return table.HasSuit(suit);
         }
 
-        protected override int Value => 1000000 * GetSuitValue(suit);
+        protected override int GenericPokerHand => 8;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            return 0;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/FourOfKind.cs
+++ b/src/Blef.GameLogic/PokerHands/FourOfKind.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
 {
@@ -16,6 +17,18 @@ namespace Blef.GameLogic.PokerHands
             return table.GetAllCards().Count(x => x.Rank == rank) == 4;
         }
 
-        protected override int Value => 10000000 * GetRankValue(rank);
+        protected override int GenericPokerHand => 9;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherFourOfKind = otherPokerHand as FourOfKind;
+
+            if (otherFourOfKind == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return rank - otherFourOfKind.rank;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/FullHouse.cs
+++ b/src/Blef.GameLogic/PokerHands/FullHouse.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
 {
@@ -20,6 +21,30 @@ namespace Blef.GameLogic.PokerHands
             return firstRankCount >= 3 && secondRankCount >= 2;
         }
 
-        protected override int Value => 100000 + 10 * GetRankValue(first) +  GetRankValue(second);
+        protected override int GenericPokerHand => 7;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherFullHouse = otherPokerHand as FullHouse;
+
+            if (otherFullHouse == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return CompareWithinSameGenericPokerHand(otherFullHouse);
+        }
+
+        int CompareWithinSameGenericPokerHand(FullHouse otherFullHouse)
+        {
+            int firstRankResult = first - otherFullHouse.first;
+
+            if (firstRankResult == 0)
+            {
+                return second - otherFullHouse.second;
+            }
+
+            return firstRankResult;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/HighCard.cs
+++ b/src/Blef.GameLogic/PokerHands/HighCard.cs
@@ -1,10 +1,12 @@
 ﻿
+using System;
+
 namespace Blef.GameLogic.PokerHands
 {
     public class HighCard : PokerHand
     {
         private readonly Rank rank;
-        
+
         public HighCard(Rank rank)
         {
             this.rank = rank;
@@ -15,6 +17,18 @@ namespace Blef.GameLogic.PokerHands
             return table.HasRank(rank);
         }
 
-        protected override int Value => GetRankValue(rank);
+        protected override int GenericPokerHand => 1;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            HighCard otherHighCard = otherPokerHand as HighCard;
+
+            if (otherHighCard == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return rank - otherHighCard.rank;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/HighStraight.cs
+++ b/src/Blef.GameLogic/PokerHands/HighStraight.cs
@@ -11,6 +11,11 @@
                table.HasRank(Rank.Ace);
         }
 
-        protected override int Value => 5000;
+        protected override int GenericPokerHand => 5;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            return 0;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/HighStraightFlush.cs
+++ b/src/Blef.GameLogic/PokerHands/HighStraightFlush.cs
@@ -1,9 +1,10 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
 {
-    public class HighStraightFlush:PokerHand
+    public class HighStraightFlush : PokerHand
     {
         private readonly Suit suit;
         private readonly IReadOnlyCollection<Card> cards;
@@ -26,6 +27,18 @@ namespace Blef.GameLogic.PokerHands
             return cards.All(table.HasCard);
         }
 
-        protected override int Value => 1000000000 * GetSuitValue(suit);
+        protected override int GenericPokerHand => 11;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherHightStraightFlush = otherPokerHand as HighStraightFlush;
+
+            if (otherHightStraightFlush == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return suit - otherHightStraightFlush.suit;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/LowStraight.cs
+++ b/src/Blef.GameLogic/PokerHands/LowStraight.cs
@@ -11,7 +11,11 @@
                    table.HasRank(Rank.King);
         }
 
-        protected override int Value => 1000;
+        protected override int GenericPokerHand => 4;
 
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            return 0;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/LowStraightFlush.cs
+++ b/src/Blef.GameLogic/PokerHands/LowStraightFlush.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
@@ -26,7 +27,18 @@ namespace Blef.GameLogic.PokerHands
             return cards.All(table.HasCard);
         }
 
-        protected override int Value => 100000000 * GetSuitValue(suit);
+        protected override int GenericPokerHand => 10;
 
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherLowStraightFlush = otherPokerHand as LowStraightFlush;
+
+            if (otherLowStraightFlush == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return suit - otherLowStraightFlush.suit;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/Pair.cs
+++ b/src/Blef.GameLogic/PokerHands/Pair.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
 {
@@ -16,6 +17,18 @@ namespace Blef.GameLogic.PokerHands
             return table.GetAllCards().Count(x => x.Rank == rank) >= 2;
         }
 
-        protected override int Value => 10 * GetRankValue(rank);
+        protected override int GenericPokerHand => 2;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherPair = otherPokerHand as Pair;
+
+            if (otherPair == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return rank - otherPair.rank;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/PokerHand.cs
+++ b/src/Blef.GameLogic/PokerHands/PokerHand.cs
@@ -1,57 +1,23 @@
-﻿using System;
-
-namespace Blef.GameLogic.PokerHands
+﻿namespace Blef.GameLogic.PokerHands
 {
     public abstract class PokerHand
     {
         public abstract bool IsOnTable(Table table);
 
-        protected abstract int Value
+        public int CompareWith(PokerHand otherPokerHand)
         {
-            get;
-        }
+            int genericValueResult = GenericPokerHand - otherPokerHand.GenericPokerHand;
 
-        public bool IsStrongerThan(PokerHand otherPokerHand)
-        {
-            return this.Value > otherPokerHand.Value;
-        }
-
-        protected int GetRankValue(Rank rank)
-        {
-            switch (rank)
+            if (genericValueResult == 0)
             {
-                case Rank.Nine:
-                    return 1;
-                case Rank.Ten:
-                    return 2;
-                case Rank.Jack:
-                    return 3;
-                case Rank.Queen:
-                    return 4;
-                case Rank.King:
-                    return 5;
-                case Rank.Ace:
-                    return 6;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(rank), rank, null);
+                return CompareWithinSameGenericPokerHand(otherPokerHand);
             }
+
+            return genericValueResult;
         }
 
-        protected int GetSuitValue(Suit suit)
-        {
-            switch (suit)
-            {
-                case Suit.Spades:
-                    return 4;
-                case Suit.Hearts:
-                    return 3;
-                case Suit.Diamonds:
-                    return 2;
-                case Suit.Clubs:
-                    return 1;
-                default:
-                    throw new ArgumentOutOfRangeException(nameof(suit), suit, null);
-            }
-        }
+        protected abstract int GenericPokerHand { get; }
+
+        protected abstract int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand);
     }
 }

--- a/src/Blef.GameLogic/PokerHands/ThreeOfKind.cs
+++ b/src/Blef.GameLogic/PokerHands/ThreeOfKind.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
 {
@@ -16,6 +17,18 @@ namespace Blef.GameLogic.PokerHands
             return table.GetAllCards().Count(x => x.Rank == rank) >= 3;
         }
 
-        protected override int Value => 10000 + 3* GetRankValue(rank);
+        protected override int GenericPokerHand => 6;
+
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherThreeOfKind = otherPokerHand as ThreeOfKind;
+
+            if (otherThreeOfKind == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return rank - otherThreeOfKind.rank;
+        }
     }
 }

--- a/src/Blef.GameLogic/PokerHands/TwoPairs.cs
+++ b/src/Blef.GameLogic/PokerHands/TwoPairs.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Blef.GameLogic.PokerHands
 {
@@ -20,8 +21,30 @@ namespace Blef.GameLogic.PokerHands
             return firstRankCount >= 2 && secondRankCount >= 2;
         }
 
-        protected override int Value => 100 + GetRankValue(first) + GetRankValue(second);
+        protected override int GenericPokerHand => 3;
 
+        protected override int CompareWithinSameGenericPokerHand(PokerHand otherPokerHand)
+        {
+            var otherTwoPair = otherPokerHand as TwoPairs;
 
+            if (otherTwoPair == null)
+            {
+                throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
+            }
+
+            return CompareWithinSameGenericPokerHand(otherTwoPair);
+        }
+
+        int CompareWithinSameGenericPokerHand(TwoPairs otherTwoPair)
+        {
+            int firstRankResult = first - otherTwoPair.first;
+
+            if (firstRankResult == 0)
+            {
+                return second - otherTwoPair.second;
+            }
+
+            return firstRankResult;
+        }
     }
 }

--- a/src/tests/Blef.GameLogic.Tests/PokerHands/TwoPairHandTests.cs
+++ b/src/tests/Blef.GameLogic.Tests/PokerHands/TwoPairHandTests.cs
@@ -11,7 +11,7 @@ namespace Blef.GameLogic.Tests.PokerHands
             TwoPairs A9 = new TwoPairs(Rank.Ace, Rank.Nine);
             TwoPairs KQ = new TwoPairs(Rank.King, Rank.Queen);
 
-            Assert.True(A9.IsStrongerThan(KQ));
+            Assert.True(A9.CompareWith(KQ) > 0);
         }
     }
 }


### PR DESCRIPTION
Opis w !PokerHandHierarchy.txt

Najpierw porównujemy czy np 2 pary są lepsze od jednej pary. Bo gdy są to już mamy wynik porównania.
Gdy spotykają się ręcę tego samego typu, np 2 pary i 2 pary to wtedy następuje porównanie wewnątrz CompareWithinSameGenericPokerHand() czyli najpierw starsza pary, później młodsza para.

Może kod 
`var otherFullHouse = otherPokerHand as FullHouse;

if (otherFullHouse == null)
{
    throw new InvalidOperationException($"This method can compare only {nameof(PokerHand)} with the same GenericPokerHand value");
}`
jest przesadzony i wystarczy coś jak:

`var otherFullHouse = (FullHouse)otherPokerHand;
`